### PR TITLE
Update cato_deploy.json

### DIFF
--- a/cato_deploy.json
+++ b/cato_deploy.json
@@ -111,7 +111,6 @@
             "properties": 
             {
                 "Application_Type": "web",
-                "RetentionInDays": 90,
                 "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('SentinelWorkspace'))]",
                 "IngestionMode": "LogAnalytics",
                 "publicNetworkAccessForIngestion": "Enabled",
@@ -213,7 +212,6 @@
             "name": "[variables('tableEventName')]",
             "properties": 
             {
-                "totalRetentionInDays": 30,
                 "plan": "Analytics",
                 "schema": 
                 {
@@ -258,7 +256,6 @@
             "name": "[variables('tableAuditName')]",
             "properties": 
             {
-                "totalRetentionInDays": 30,
                 "plan": "Analytics",
                 "schema": 
                 {
@@ -287,7 +284,6 @@
             "name": "[variables('tableStoriesName')]",
             "properties": 
             {
-                "totalRetentionInDays": 30,
                 "plan": "Analytics",
                 "schema": 
                 {


### PR DESCRIPTION
Removed retention settings so deployment does not attempt to change retention on main workspace to 90 days and does not attempt to set retention on new tables it is creating.
Attempting to set table retention was causing failures during deployment - generally these should be inherited from the existing workspace settings anyway.